### PR TITLE
[bugfix] cancel rebind6 timer after ipv6 expire

### DIFF
--- a/client/dhc6.c
+++ b/client/dhc6.c
@@ -4656,6 +4656,10 @@ dhc6_check_times(struct client_state *client)
 		 * depreffed an address.
 		 */
 		client->MRD = hi_expire - cur_time;
+		/* Rebind expired, cancel rebind(do_refresh6) timer. */
+		if (client->MRD == 0) {
+			cancel_timeout(do_refresh6, client);
+		}
 		break;
 
 	      default:


### PR DESCRIPTION
Solve below question:
Oct 23 16:38:04 localhost dhclient[141133]: PRC: Address 6636::3c depreferred.
Oct 23 16:38:04 localhost dhclient[141133]: XMT: Rebind on enp4s0, interval 00ms.
Oct 23 16:38:04 localhost dhclient[141133]: Impossible condition at dhc6.c:279.
Oct 23 16:38:04 localhost dhclient[141133]:
Oct 23 16:38:04 localhost dhclient[141133]: If you think you have received this message due to a bug rather
Oct 23 16:38:04 localhost dhclient[141133]: than a configuration issue please read the section on submitting
Oct 23 16:38:04 localhost dhclient[141133]: bugs on either our web page at [www.isc.org](http://www.isc.org/) or in the README file
Oct 23 16:38:04 localhost dhclient[141133]: before submitting a bug. These pages explain the proper
Oct 23 16:38:04 localhost dhclient[141133]: process and the information we find helpful for debugging.
Oct 23 16:38:04 localhost dhclient[141133]:
Oct 23 16:38:04 localhost dhclient[141133]: exiting.

The reason is:
After the REBIND message is retransmitted for the second time, the REBIND timer checks whether the REBIND message
is received 5 seconds later and sets the RT field to 0. (Because the 5s timer expires when the timer expires, no next
retransmission will occur.)
After 5s, the DEPREFER timer is triggered first. The DEPREFER timer considers that the REBIND timer expires and set
MRD field to 0, but the previously set REBIND timer is not canceled.
The REBIND timer is triggered immediately. Because the MRD is set to 0, the retransmission timer considers that the
maximum retransmission duration is not limited and attempts to continue the retransmission.
During the retransmission process, the RT value is 0 (retransmission is performed after 0s), and the process exits.
As a result, the DHCP6 function becomes abnormal.
Solution:
Cencle REBIND timer when DEPREFER timer considers that the REBIND timer expires.